### PR TITLE
Condense SQL schema.

### DIFF
--- a/UtopiaRDS/utopiaAirlineSchema.sql
+++ b/UtopiaRDS/utopiaAirlineSchema.sql
@@ -1,51 +1,12 @@
--- MySQL dump 10.13  Distrib 8.0.16, for Win64 (x86_64)
---
--- Host: localhost    Database: utopiaairlines
--- ------------------------------------------------------
--- Server version	8.0.12
-
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
- SET NAMES utf8 ;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-
---
--- Table structure for table `tbl_airports`
---
-
-DROP TABLE IF EXISTS `tbl_airports`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+CREATE DATABASE IF NOT EXISTS `utopia`;
+USE `utopia`;
 CREATE TABLE `tbl_airports` (
   `code` char(3) NOT NULL,
   `name` varchar(45) NOT NULL,
   PRIMARY KEY (`code`),
   UNIQUE KEY `idtbl_airports_UNIQUE` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
+);
 
---
--- Dumping data for table `tbl_airports`
---
-
-LOCK TABLES `tbl_airports` WRITE;
-/*!40000 ALTER TABLE `tbl_airports` DISABLE KEYS */;
-/*!40000 ALTER TABLE `tbl_airports` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `tbl_flights`
---
-
-DROP TABLE IF EXISTS `tbl_flights`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
 CREATE TABLE `tbl_flights` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `departure` char(3) NOT NULL,
@@ -59,25 +20,18 @@ CREATE TABLE `tbl_flights` (
   KEY `destination_idx` (`destination`),
   CONSTRAINT `departure` FOREIGN KEY (`departure`) REFERENCES `tbl_airports` (`code`),
   CONSTRAINT `destination` FOREIGN KEY (`destination`) REFERENCES `tbl_airports` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
+);
 
---
--- Dumping data for table `tbl_flights`
---
+CREATE TABLE `tbl_users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `username` varchar(45) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `display_name` varchar(45) DEFAULT NULL,
+  `role` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id_UNIQUE` (`id`)
+);
 
-LOCK TABLES `tbl_flights` WRITE;
-/*!40000 ALTER TABLE `tbl_flights` DISABLE KEYS */;
-/*!40000 ALTER TABLE `tbl_flights` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `tbl_tickets`
---
-
-DROP TABLE IF EXISTS `tbl_tickets`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
 CREATE TABLE `tbl_tickets` (
   `flight` int(11) NOT NULL,
   `row` int(11) NOT NULL,
@@ -90,52 +44,4 @@ CREATE TABLE `tbl_tickets` (
   KEY `reserver_idx` (`reserver`),
   CONSTRAINT `flight` FOREIGN KEY (`flight`) REFERENCES `tbl_flights` (`id`),
   CONSTRAINT `reserver` FOREIGN KEY (`reserver`) REFERENCES `tbl_users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `tbl_tickets`
---
-
-LOCK TABLES `tbl_tickets` WRITE;
-/*!40000 ALTER TABLE `tbl_tickets` DISABLE KEYS */;
-/*!40000 ALTER TABLE `tbl_tickets` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `tbl_users`
---
-
-DROP TABLE IF EXISTS `tbl_users`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
-CREATE TABLE `tbl_users` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `username` varchar(45) NOT NULL,
-  `password` varchar(255) NOT NULL,
-  `display_name` varchar(45) DEFAULT NULL,
-  `role` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `id_UNIQUE` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `tbl_users`
---
-
-LOCK TABLES `tbl_users` WRITE;
-/*!40000 ALTER TABLE `tbl_users` DISABLE KEYS */;
-/*!40000 ALTER TABLE `tbl_users` ENABLE KEYS */;
-UNLOCK TABLES;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
-
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on 2019-06-03 17:42:21
+);


### PR DESCRIPTION
In this commit, I condensed the SQL schema by removing everything except the `CREATE TABLE` calls, including the character-encoding and storage-engine metadata at the end of those calls. To ensure that the schema should still work (though I didn't actually test loading this into an empty database), I moved the `users` table to before the `tickets` table that references it, and also added `CREATE DATABASE IF NOT EXISTS` and `USE` statements at the beginning.