### PR TITLE
Fix 'airport' vs 'flight' mixup in Swagger

### DIFF
--- a/api/utopia-swagger.yml
+++ b/api/utopia-swagger.yml
@@ -466,7 +466,7 @@ definitions:
     - "time"
     properties:
       airport:
-        $ref: "#/definitions/Flight"
+        $ref: "#/definitions/Airport"
       time:
         type: "string"
         format: "date-time"


### PR DESCRIPTION
In Swagger, fix spurious reference to 'airport' of type 'flight'. This is the issue that came up in the presentation on Saturday.