### PR TITLE
Rename 'row' column of tickets table to 'seat_row'

### DIFF
--- a/UtopiaRDS/utopiaAirlineSchema.sql
+++ b/UtopiaRDS/utopiaAirlineSchema.sql
@@ -39,14 +39,14 @@ CREATE TABLE `tbl_users` (
 
 CREATE TABLE `tbl_tickets` (
   `flight` int(11) NOT NULL,
-  `row` int(11) NOT NULL,
+  `seat_row` int(11) NOT NULL,
   `seat` char(1) NOT NULL,
   `class` int(11) NOT NULL,
   `reserver` int(11) DEFAULT NULL,
   `price` int(11) DEFAULT NULL,
   `reservation_timeout` datetime DEFAULT NULL,
   `booking_id` VARCHAR(45) DEFAULT NULL,
-  PRIMARY KEY (`flight`,`row`,`seat`),
+  PRIMARY KEY (`flight`,`seat_row`,`seat`),
   KEY `reserver_idx` (`reserver`),
   CONSTRAINT `flight` FOREIGN KEY (`flight`) REFERENCES `tbl_flights` (`id`),
   CONSTRAINT `reserver` FOREIGN KEY (`reserver`) REFERENCES `tbl_users` (`id`),


### PR DESCRIPTION
Unlike the `class` column, which has a Java keyword as its name, causing us to have to name the corresponding fields something else and explicitly point them to it, the `row` column has a *SQL* keyword as its name, which causes the JDBC layer to throw exceptions at runtime because Hibernate doesn't think to quote it. There may be some way to force Hibernate to always quote a given name, but the easiest way of getting the JPA engine to work without error is simply to rename the column.

This PR doesn't yet contain a corresponding change to the E-R diagram or the Workbench archive; please feel free to add a commit or commits making those changes to the PR before merging it.