### PR TITLE
Increase airport table field lengths

### DIFF
--- a/UtopiaRDS/utopiaAirlineSchema.sql
+++ b/UtopiaRDS/utopiaAirlineSchema.sql
@@ -1,7 +1,7 @@
 CREATE DATABASE IF NOT EXISTS `utopia`;
 USE `utopia`;
 CREATE TABLE `tbl_airports` (
-  `code` char(3) NOT NULL,
+  `code` char(4) NOT NULL,
   `name` varchar(45) NOT NULL,
   PRIMARY KEY (`code`),
   UNIQUE KEY `idtbl_airports_UNIQUE` (`code`)

--- a/UtopiaRDS/utopiaAirlineSchema.sql
+++ b/UtopiaRDS/utopiaAirlineSchema.sql
@@ -2,7 +2,7 @@ CREATE DATABASE IF NOT EXISTS `utopia`;
 USE `utopia`;
 CREATE TABLE `tbl_airports` (
   `code` char(4) NOT NULL,
-  `name` varchar(45) NOT NULL,
+  `name` varchar(75) NOT NULL,
   PRIMARY KEY (`code`),
   UNIQUE KEY `idtbl_airports_UNIQUE` (`code`)
 );


### PR DESCRIPTION
I'd like to increase the length of both fields in the table of airports. I've found a dataset of (nearly) all airports in the world, and many have a 4-character code, a "name" over 45 characters, or both.